### PR TITLE
Add guard against infinity coordinates

### DIFF
--- a/ShowCenterLines.glyphsReporter/Contents/Resources/plugin.py
+++ b/ShowCenterLines.glyphsReporter/Contents/Resources/plugin.py
@@ -12,7 +12,7 @@
 ###########################################################################################################
 
 import objc
-from math import radians, tan
+from math import isinf, radians, tan
 from Foundation import NSMidX, NSMidY, NSAffineTransform, NSMakePoint, NSPoint, NSColor, NSBezierPath
 from GlyphsApp import Glyphs
 from GlyphsApp.plugins import ReporterPlugin
@@ -101,6 +101,8 @@ class ShowCenterLines(ReporterPlugin):
 				italicAngle=angle,
 				pivotalY=0.0,
 			)
+		if isinf(x) or isinf(y):
+			return
 
 		cross = NSBezierPath.bezierPath()
 		if angle != 0:


### PR DESCRIPTION
When selecting an extra node (`GSHandle`) in Glyphs 4, the plugin displayed this alert on a loop, often requiring the user to force quit Glyphs:

<img width="1368" height="908" alt="CleanShot 2026-08-05 at 08 19 36@2x" src="https://github.com/user-attachments/assets/a27370a1-dbfc-4c09-a885-6ded0f9ee743" />

As far as I can tell, the reason is that Glyphs 3 used to return a very large finite value for the coordinates of `layer.selectionBounds` when a `GSHandle` was selected: 
```
<CoreFoundation.CGRect origin=<CoreFoundation.CGPoint x=9.223372036854776e+18 y=100000.0> size=<CoreFoundation.CGSize width=-100000.0 height=-100000.0>>
```

But Glyphs 4 now returns infinity:
```
<CoreFoundation.CGRect origin=<CoreFoundation.CGPoint x=inf y=inf> size=<CoreFoundation.CGSize width=0.0 height=0.0>>
```

I added a guard against infinity values so it returns early and the plugin doesn’t error out.